### PR TITLE
fix stream redirect order

### DIFF
--- a/templates/etc/init/template
+++ b/templates/etc/init/template
@@ -49,7 +49,7 @@ script
 {%   endfor %}
 end script
 {% else %}
-exec start-stop-daemon --start --chuid {{ upstart_user }} --group {{ upstart_group }} --make-pidfile --pidfile {{ upstart_pidfile_path }} --exec {{ upstart_exec_path }}{{ ' -- '~upstart_exec_flags|join(' ') if upstart_exec_flags else '' }} {{ '2>&1' if upstart_capture_errors else '' }} >> {{ upstart_log_path }}
+exec start-stop-daemon --start --chuid {{ upstart_user }} --group {{ upstart_group }} --make-pidfile --pidfile {{ upstart_pidfile_path }} --exec {{ upstart_exec_path }}{{ ' -- '~upstart_exec_flags|join(' ') if upstart_exec_flags else '' }} >> {{ upstart_log_path }} {{ '2>&1' if upstart_capture_errors else '' }}
 {% endif %}
 
 post-stop script


### PR DESCRIPTION
This change fixes the stream redirect order when upstart_capture_errors
is set to true. Without the correct order stderr is not captured.